### PR TITLE
Es index work

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -81,6 +81,31 @@
   version = "v1.6.2"
 
 [[projects]]
+  branch = "master"
+  digest = "1:212bebc561f4f654a653225868b2a97353cd5e160dc0b0bbc7232b06608474ec"
+  name = "github.com/mailru/easyjson"
+  packages = [
+    ".",
+    "buffer",
+    "jlexer",
+    "jwriter",
+  ]
+  pruneopts = ""
+  revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
+
+[[projects]]
+  digest = "1:84888145afd06f7e80db09851e0c4ec22996658d5075185b12040c5d46e65eee"
+  name = "github.com/olivere/elastic"
+  packages = [
+    ".",
+    "config",
+    "uritemplates",
+  ]
+  pruneopts = ""
+  revision = "4982266e48e0dc5c639e389b50221dcef09cdc99"
+  version = "v6.2.12"
+
+[[projects]]
   digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -150,6 +175,7 @@
     "github.com/globalsign/mgo/bson",
     "github.com/gorilla/handlers",
     "github.com/gorilla/mux",
+    "github.com/olivere/elastic",
     "github.com/pkg/errors",
     "github.com/remeh/sizedwaitgroup",
     "github.com/sirupsen/logrus",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,97 +3,158 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:a74730e052a45a3fab1d310fdef2ec17ae3d6af16228421e238320846f2aaec8"
   name = "github.com/alecthomas/template"
-  packages = [".","parse"]
+  packages = [
+    ".",
+    "parse",
+  ]
+  pruneopts = ""
   revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
 
 [[projects]]
   branch = "master"
+  digest = "1:8483994d21404c8a1d489f6be756e25bfccd3b45d65821f25695577791a08e68"
   name = "github.com/alecthomas/units"
   packages = ["."]
+  pruneopts = ""
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
+  digest = "1:556b75e96f02319585d253d262c4ce5dfdf4b28be474f1e0877c5f4f9b10cf9e"
   name = "github.com/dlclark/regexp2"
-  packages = [".","syntax"]
+  packages = [
+    ".",
+    "syntax",
+  ]
+  pruneopts = ""
   revision = "487489b64fb796de2e55f4e8a4ad1e145f80e957"
   version = "v1.1.6"
 
 [[projects]]
   branch = "master"
+  digest = "1:5918a8e122613d70243104b8efd5339121bcb8a8a77c1ec4499f1d1e13682ab5"
   name = "github.com/exlinc/golang-utils"
-  packages = ["envconfig","jsonhttp"]
+  packages = [
+    "envconfig",
+    "jsonhttp",
+  ]
+  pruneopts = ""
   revision = "b526c57121307ce873f8cc45c01a25e3e8f31341"
 
 [[projects]]
   branch = "master"
+  digest = "1:c1e35087694b689ce1cf4f4277612b6ac0b55725fa791271ae0e3ddcd1cc0c7b"
   name = "github.com/globalsign/mgo"
-  packages = [".","bson","internal/json","internal/sasl","internal/scram"]
+  packages = [
+    ".",
+    "bson",
+    "internal/json",
+    "internal/sasl",
+    "internal/scram",
+  ]
+  pruneopts = ""
   revision = "113d3961e7311526535a1ef7042196563d442761"
 
 [[projects]]
+  digest = "1:dbbeb8ddb0be949954c8157ee8439c2adfd8dc1c9510eb44a6e58cb68c3dce28"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = ""
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:66d63ec7b6035984dced87ad37066e5f4ad277c60234a9d9925537248e983200"
   name = "github.com/gorilla/handlers"
   packages = ["."]
+  pruneopts = ""
   revision = "7e0847f9db758cdebd26c149d0ae9d5d0b9c98ce"
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:c2c8666b4836c81a1d247bdf21c6a6fc1ab586538ab56f74437c2e0df5c375e1"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = ""
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
 
 [[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:072af4062ae457d04860eeac1479f46bb01137e4dada0a1bfcd86b79ae150d9b"
   name = "github.com/remeh/sizedwaitgroup"
   packages = ["."]
+  pruneopts = ""
   revision = "5582a674300c427060d06980c142aeb52ed20040"
 
 [[projects]]
+  digest = "1:3fcbf733a8d810a21265a7f2fe08a3353db2407da052b233f8b204b5afc03d9b"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = ""
   revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
   version = "v1.0.6"
 
 [[projects]]
   branch = "master"
+  digest = "1:4cae11053a5fc8e7b08228fcc14d161d3e60b64ba508a8b216937da472690991"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
 
 [[projects]]
   branch = "master"
+  digest = "1:b779cc85de245422bf70d8a21e6afcf3c0591eca64dc507feb9f054f64b21ab9"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
   revision = "4e1fef5609515ec7a2cee7b5de30ba6d9b438cbf"
 
 [[projects]]
+  digest = "1:15d017551627c8bb091bde628215b2861bed128855343fdd570c62d08871f6e1"
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
   version = "v2.2.6"
 
 [[projects]]
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "419be1febcf5707580903ffcca069434566a53af52c9b29f21f2481630642b1e"
+  input-imports = [
+    "github.com/dlclark/regexp2",
+    "github.com/exlinc/golang-utils/envconfig",
+    "github.com/exlinc/golang-utils/jsonhttp",
+    "github.com/globalsign/mgo",
+    "github.com/globalsign/mgo/bson",
+    "github.com/gorilla/handlers",
+    "github.com/gorilla/mux",
+    "github.com/pkg/errors",
+    "github.com/remeh/sizedwaitgroup",
+    "github.com/sirupsen/logrus",
+    "gopkg.in/alecthomas/kingpin.v2",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -175,10 +175,7 @@
     "github.com/globalsign/mgo/bson",
     "github.com/gorilla/handlers",
     "github.com/gorilla/mux",
-<<<<<<< HEAD
     "github.com/olivere/elastic",
-=======
->>>>>>> master
     "github.com/pkg/errors",
     "github.com/remeh/sizedwaitgroup",
     "github.com/sirupsen/logrus",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ export ELASTICSEARCH_BASE_INDEX="learn"
 go run main.go convert --from-format eocs --from-uri <path to the course files folder> --to-format eocs --to-uri mongodb://localhost:27017
 ```
 
+### Connecting to Elasticsearch HTTPS Backend in a non-production mode 
+
+Some Elasticsearch security models, e.g., AWS VPC Elasticsearch Service, require HTTPS connectivity in either Production or Test modes. To bypass Certificate validation in testing, ensure to set
+```
+export MODE=debug
+```
+
+A full example of connecting to AWS VPC Elasticsearch Service for testing:
+```
+// This is run in a separate terminal session that creates a tunnel to the AWS VPC via any instance running in the VPC:
+ssh -i ~/.ssh/myAwsInstanceKey ec2-user@123.4.5.6 -N -L 19200:vpc-my-es-service.us-west-2.es.amazonaws.com:443
+
+// This is run in the eocsutil testing terminal session: 
+export MODE=debug
+export ELASTICSEARCH_URI="https://localhost:19200"
+```
+  
+
 ## FAQ
 
 ### I'm getting errors about showdownjs

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Command-line tool and GoLang API for working with EOCS and OLX courseware. This 
 ## Prerequisites
 
 + Linux or OS X recommended (PRs for Windows support are welcome)
-+ GoLang 1.9.^  (`GOPATH` must be set)
++ GoLang 1.10.^  (`GOPATH` must be set)
 + GoLang `dep` tool [Install Guide](https://github.com/golang/dep#setup)
 + NodeJS v8.10+
 + Yarn 1.7+
@@ -21,7 +21,7 @@ yarn install
 go build # Optional, but this will validate that you have the correct golang deps
 ```
 
-## Load EOCS course into EXLskills MongoDB
+## Load EOCS course into EXLskills MongoDB and Elasticsearch (version 6.x)
 
 ### Assumptions
 
@@ -30,6 +30,14 @@ go build # Optional, but this will validate that you have the correct golang dep
 
 ```
 export MGO_DB_NAME="<name of the MongoDB target database>"
+
+# Note: if Elasticsearch URI is not provided - the indexing will be bypassed
+export ELASTICSEARCH_URI="http://localhost:9200"
+
+# The default value for Elasticsearch "base" index is "learn". The actual index name will be set to the base plus "_<course launguage>", e.g., "base_en"
+# To override the base name, set the Environment variable as below 
+export ELASTICSEARCH_BASE_INDEX="learn"
+ 
 # Note: `go run` will compile eocsutil on the fly with any code changes, to compile ahead of time, use `go build` and then execute the binary
 go run main.go convert --from-format eocs --from-uri <path to the course files folder> --to-format eocs --to-uri mongodb://localhost:27017
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -9,12 +9,14 @@ import (
 
 type Config struct {
 	// The app is in production or debug mode
-	Mode             string `envconfig:"MODE" default:"production"`
-	MgoDBName        string `envconfig:"MGO_DB_NAME"`
-	GHWebhookSecret  string `envconfig:"GH_WEBHOOK_SECRET"`
-	GHServerAddr     string `envconfig:"GH_SERVER_ADDR" default:"0.0.0.0"`
-	GHServerPort     string `envconfig:"GH_SERVER_PORT" default:"3344"`
-	GHServerMongoURI string `envconfig:"GH_SERVER_MONGO_URI"`
+	Mode                   string `envconfig:"MODE" default:"production"`
+	MgoDBName              string `envconfig:"MGO_DB_NAME"`
+	GHWebhookSecret        string `envconfig:"GH_WEBHOOK_SECRET"`
+	GHServerAddr           string `envconfig:"GH_SERVER_ADDR" default:"0.0.0.0"`
+	GHServerPort           string `envconfig:"GH_SERVER_PORT" default:"3344"`
+	GHServerMongoURI       string `envconfig:"GH_SERVER_MONGO_URI"`
+	ElasticsearchURI       string `envconfig:"ELASTICSEARCH_URI"`
+	ElasticsearchBaseIndex string `envconfig:"ELASTICSEARCH_BASE_INDEX"`
 }
 
 var conf *Config

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	GHServerPort           string `envconfig:"GH_SERVER_PORT" default:"3344"`
 	GHServerMongoURI       string `envconfig:"GH_SERVER_MONGO_URI"`
 	ElasticsearchURI       string `envconfig:"ELASTICSEARCH_URI"`
-	ElasticsearchBaseIndex string `envconfig:"ELASTICSEARCH_BASE_INDEX"`
+	ElasticsearchBaseIndex string `envconfig:"ELASTICSEARCH_BASE_INDEX" default:"learn"`
 }
 
 var conf *Config

--- a/eocs/block_repl.go
+++ b/eocs/block_repl.go
@@ -1,6 +1,7 @@
 package eocs
 
 import (
+	"fmt"
 	"github.com/exlskills/eocsutil/wsenv"
 	"github.com/pkg/errors"
 	"io/ioutil"
@@ -71,10 +72,12 @@ func (repl *BlockREPL) LoadFilesFromFS(rootDir string) error {
 }
 
 func loadFilesFromFSForEnv(envKey, dir string) (files map[string]*wsenv.WorkspaceFile, err error) {
+	Log.Info("------------------> in loadFilesFromFSForEnv ")
 	fillinFiles, err := loadFilesFromDirRecursive(dir)
 	if err != nil {
 		return nil, err
 	}
+
 	switch envKey {
 	case "java_default_free":
 		files = map[string]*wsenv.WorkspaceFile{
@@ -106,6 +109,10 @@ func loadFilesFromFSForEnv(envKey, dir string) (files map[string]*wsenv.Workspac
 				},
 			},
 		}
+
+		for key, value := range files["src"].Children["main"].Children["java"].Children["exlcode"].Children{
+			fmt.Println("Key:", key, "Value:", value.Contents)
+		}
 		return
 	case "python_2_7_free":
 		return fillinFiles, nil
@@ -118,6 +125,7 @@ func loadFilesFromFSForEnv(envKey, dir string) (files map[string]*wsenv.Workspac
 }
 
 func loadFilesFromDirRecursive(dir string) (files map[string]*wsenv.WorkspaceFile, err error) {
+	Log.Info("------------------> in loadFilesFromDirRecursive ")
 	dirListing, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return nil, err

--- a/eocs/course.go
+++ b/eocs/course.go
@@ -481,6 +481,7 @@ func convertToESCourse(course *Course) (esc *esmodels.Course, exams []*esmodels.
 		Title:       course.DisplayName,
 		Headline:    course.GetExtraAttributes()["headline"],
 		TextContent: course.GetExtraAttributes()["description"],
+		CourseId:    course.URLName,
 	}
 	esearchdocs = append(esearchdocs, esearchdoc)
 	return
@@ -534,16 +535,13 @@ func extractESUnitFeatures(courseID string, courseRepoUrl string, chap *Chapter,
 		Sections: sections,
 	}
 
-	courseItemRefUnit := esmodels.CourseItemRef{
-		CourseID: courseID,
-	}
-	courseItemRefUnitJson, _ := json.Marshal(courseItemRefUnit)
 	esearchdoc := &esmodels.ElasticsearchGenDoc{
 		ID:       toGlobalId("Unit", unit.ID),
 		DocType:  "unit",
 		Title:    chap.DisplayName,
 		Headline: "Learn " + chap.DisplayName,
-		DocRef:   string(courseItemRefUnitJson),
+		CourseId: courseID,
+		UnitId:   unit.ID,
 	}
 	esearchdocs = append(esearchdocs, esearchdoc)
 
@@ -894,7 +892,6 @@ func extractESSectionFeatures(courseID, courseRepoUrl, unitID string, index int,
 		section.Cards.Cards = append(section.Cards.Cards, card)
 		Log.Info("Added Card ", vert.DisplayName)
 
-		courseItemRefCardJson, _ := json.Marshal(card.CourseItemRef)
 		esearchdoc := &esmodels.ElasticsearchGenDoc{
 			ID:          toGlobalId("Card", vert.URLName),
 			DocType:     "card",
@@ -902,22 +899,22 @@ func extractESSectionFeatures(courseID, courseRepoUrl, unitID string, index int,
 			Headline:    "Learn " + vert.DisplayName,
 			TextContent: cardText.String(),
 			CodeContent: cardCode.String(),
-			DocRef:      string(courseItemRefCardJson),
+			CourseId: courseID,
+			UnitId:   unitID,
+			SectionId: sequential.URLName,
+			CardId:   vert.URLName,
 		}
 		esearchdocs = append(esearchdocs, esearchdoc)
 	}
 
-	courseItemRefSection := esmodels.CourseItemRef{
-		CourseID: courseID,
-		UnitID:   unitID,
-	}
-	courseItemRefSectionJson, _ := json.Marshal(courseItemRefSection)
 	esearchdoc := &esmodels.ElasticsearchGenDoc{
 		ID:       toGlobalId("Section", section.ID),
 		DocType:  "section",
 		Title:    sequential.DisplayName,
 		Headline: "Learn " + sequential.DisplayName,
-		DocRef:   string(courseItemRefSectionJson),
+		CourseId: courseID,
+		UnitId:   unitID,
+        SectionId: section.ID,
 	}
 	esearchdocs = append(esearchdocs, esearchdoc)
 	return

--- a/eocs/course.go
+++ b/eocs/course.go
@@ -389,7 +389,7 @@ func upsertCourseRecursive(course *Course, mongoURI, dbName string, elasticsearc
 			elasticSearchClient, err = elastic.NewClient(elastic.SetHttpClient(client), elastic.SetSniff(false), elastic.SetURL(elasticsearchURI))
 		} else {
 			// This is used in Production and for HTTP backend testing
-			elasticSearchClient, err = elastic.NewClient(elastic.SetURL(elasticsearchURI))
+			elasticSearchClient, err = elastic.NewClient(elastic.SetSniff(false), elastic.SetURL(elasticsearchURI))
 		}
 		if err != nil {
 			Log.Errorf("Elasticsearch connection issue for URI: %v. Error: %s", elasticsearchURI, err.Error())

--- a/eocs/eocs.go
+++ b/eocs/eocs.go
@@ -52,5 +52,5 @@ func (e *EOCS) Push(fromUri, toUri string) error {
 	if config.Cfg().MgoDBName == "" {
 		return errors.New("for EOCS course conversion the MGO_DB_NAME environment variable must be set to the name of the MongoDB database to write to")
 	}
-	return upsertCourseRecursive(course, toUri, config.Cfg().MgoDBName)
+	return upsertCourseRecursive(course, toUri, config.Cfg().MgoDBName, config.Cfg().ElasticsearchURI, config.Cfg().ElasticsearchBaseIndex)
 }

--- a/eocs/esmodels/card.go
+++ b/eocs/esmodels/card.go
@@ -7,7 +7,6 @@ type Card struct {
 	Index         int               `bson:"index"`
 	ContentID     string            `bson:"content_id"`
 	QuestionIDs   []string          `bson:"question_ids"`
-	CardRef       DocRef            `bson:"card_ref"`
 	CourseItemRef CourseItemRef     `bson:"course_item_ref"`
 	Tags          []string          `bson:"tags"`
 }

--- a/eocs/esmodels/elasticsearch_gen_doc.go
+++ b/eocs/esmodels/elasticsearch_gen_doc.go
@@ -1,0 +1,11 @@
+package esmodels
+
+type ElasticsearchGenDoc struct {
+	ID          string
+	DocType     string `json:"doc_type"`
+	Title       string `json:"title"`
+	Headline    string `json:"headline"`
+	TextContent string `json:"text_content"`
+	CodeContent string `json:"code_content"`
+	DocRef      string `json:"doc_ref"`
+}

--- a/eocs/esmodels/elasticsearch_gen_doc.go
+++ b/eocs/esmodels/elasticsearch_gen_doc.go
@@ -1,11 +1,11 @@
 package esmodels
 
 type ElasticsearchGenDoc struct {
-	ID          string
+	ID          string `json:"-"`
 	DocType     string `json:"doc_type"`
-	Title       string `json:"title"`
-	Headline    string `json:"headline"`
-	TextContent string `json:"text_content"`
-	CodeContent string `json:"code_content"`
-	DocRef      string `json:"doc_ref"`
+	Title       string `json:"title,omitempty"`
+	Headline    string `json:"headline,omitempty"`
+	TextContent string `json:"text_content,omitempty"`
+	CodeContent string `json:"code_content,omitempty"`
+	DocRef      string `json:"doc_ref,omitempty"`
 }

--- a/eocs/esmodels/elasticsearch_gen_doc.go
+++ b/eocs/esmodels/elasticsearch_gen_doc.go
@@ -7,5 +7,8 @@ type ElasticsearchGenDoc struct {
 	Headline    string `json:"headline,omitempty"`
 	TextContent string `json:"text_content,omitempty"`
 	CodeContent string `json:"code_content,omitempty"`
-	DocRef      string `json:"doc_ref,omitempty"`
+	CourseId    string `json:"course_id,omitempty"`
+	UnitId    string `json:"unit_id,omitempty"`
+	SectionId    string `json:"section_id,omitempty"`
+	CardId    string `json:"card_id,omitempty"`
 }

--- a/eocs/utils.go
+++ b/eocs/utils.go
@@ -1,6 +1,7 @@
 package eocs
 
 import (
+	"encoding/base64"
 	"fmt"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
@@ -78,4 +79,8 @@ func concatExtraAttrCSV(list []string) string {
 
 func extraAttrCSVToStrSlice(str string) []string {
 	return strings.Split(str, ",")
+}
+
+func toGlobalId (prefix string, id string) string {
+	return base64.StdEncoding.EncodeToString([]byte(prefix + ":" +id))
 }

--- a/ghserver/repo_push_event_webhook.go
+++ b/ghserver/repo_push_event_webhook.go
@@ -49,7 +49,7 @@ func repoPushEventWebhook(w http.ResponseWriter, r *http.Request) {
 	courseDir := unzippedFilePaths[0]
 	err = eocs.NewEOCSFormat().Push(courseDir, config.Cfg().GHServerMongoURI)
 	if err != nil {
-		Log.Errorf("Course mongodb push failed: %s", err.Error())
+		Log.Errorf("Course push failed: %s", err.Error())
 		jsonhttp.JSONInternalError(w, "An error occurred importing the course", "")
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func run() {
 		if strings.HasPrefix(*convertToURI, "mongodb://") {
 			err := eocs.NewEOCSFormat().Push(*convertFromURI, *convertToURI)
 			if err != nil {
-				Log.Errorf("Course mongodb push failed: %s", err.Error())
+				Log.Errorf("Course push failed: %s", err.Error())
 				return
 			}
 			return

--- a/olx/block.go
+++ b/olx/block.go
@@ -31,6 +31,7 @@ func appendIRBlocksToVertical(vert *Vertical, blocks []ir.Block) (err error) {
 		}
 		var nodes []*BlockNode
 		olxStr, err := b.GetContentOLX()
+		Log.Info("olxStr: ", olxStr)
 		if err != nil {
 			if b.GetBlockType() == "html" {
 				md, err := b.GetContentMD()
@@ -39,6 +40,7 @@ func appendIRBlocksToVertical(vert *Vertical, blocks []ir.Block) (err error) {
 					return err
 				}
 				olxStr, err = mdutils.MakeHTML(md, "github")
+				Log.Info("md: ", olxStr)
 				if err != nil {
 					return errors.New(fmt.Sprintf("olx: error converting md to OLX: %s", err.Error()))
 				}

--- a/olx/course.go
+++ b/olx/course.go
@@ -56,6 +56,7 @@ func exportCourseRecursive(course ir.Course, rootDir string) (err error) {
 		Language:    course.GetLanguage(),
 		ExtraAttrs:  mapToXMLAttrs(course.GetExtraAttributes()),
 	}
+	Log.Info(`in exportCourseRecursive`)
 	err = appendIRChaptersToCourse(courseFile, course.GetChapters())
 	if err != nil {
 		return err

--- a/wsenv/workspace.go
+++ b/wsenv/workspace.go
@@ -28,7 +28,6 @@ func (wfs *Workspace) SetupFileSystem(rootPath string) error {
 
 // Returns: indices to find file from root filesystem map, pointer to WorkspaceFile, relative path to file, error
 func (wfs *Workspace) GetFileRef(isSudoMode bool, relPath string) ([]string, *WorkspaceFile, string, error) {
-	Log.Info("---------------> in GetFileRef  ")
 	inds := make([]string, 0)
 	if err := basicFileNameCheck(relPath); err != nil {
 		return inds, nil, "", err

--- a/wsenv/workspace.go
+++ b/wsenv/workspace.go
@@ -2,8 +2,11 @@ package wsenv
 
 import (
 	"errors"
+	"github.com/exlskills/eocsutil/config"
 	"strings"
 )
+
+var Log = config.Cfg().GetLogger()
 
 type Workspace struct {
 	Id             string                    `json:"id"`
@@ -25,6 +28,7 @@ func (wfs *Workspace) SetupFileSystem(rootPath string) error {
 
 // Returns: indices to find file from root filesystem map, pointer to WorkspaceFile, relative path to file, error
 func (wfs *Workspace) GetFileRef(isSudoMode bool, relPath string) ([]string, *WorkspaceFile, string, error) {
+	Log.Info("---------------> in GetFileRef  ")
 	inds := make([]string, 0)
 	if err := basicFileNameCheck(relPath); err != nil {
 		return inds, nil, "", err


### PR DESCRIPTION
Code to load Elasticsearch data has been developed and tested. If ELASTICSEARCH_URI env var is not provided to the process - the code is entirely bypassed. Once merged and deployed, the container can be updated at a later point. The webhook-based load has not been tested, but the Elasticsearch process is coded into the same method that populates MongoDB, so it should be executed in a similar fashion in either flow. The data for the load is gathered along with that used for the MongoDb load - all methods in the flow have been updated 