### PR TITLE
add yaml skill_level to course parser logic

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,6 +32,21 @@
   version = "v1.1.6"
 
 [[projects]]
+  digest = "1:f21c1a68814ffc02db479adbd973c710e0ece6150ddc0726655c0a2048299152"
+  name = "github.com/emirpasic/gods"
+  packages = [
+    "containers",
+    "lists",
+    "lists/arraylist",
+    "trees",
+    "trees/binaryheap",
+    "utils",
+  ]
+  pruneopts = ""
+  revision = "1615341f118ae12f353cc8a983f35b584342c9b3"
+  version = "v1.12.0"
+
+[[projects]]
   branch = "master"
   digest = "1:5918a8e122613d70243104b8efd5339121bcb8a8a77c1ec4499f1d1e13682ab5"
   name = "github.com/exlinc/golang-utils"
@@ -82,6 +97,22 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:95abc4eba158a39873bd4fabdee576d0ae13826b550f8b710881d80ae4093a0f"
+  name = "github.com/jbenet/go-context"
+  packages = ["io"]
+  pruneopts = ""
+  revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
+
+[[projects]]
+  digest = "1:41e0bed5df4f9fd04c418bf9b6b7179b3671e416ad6175332601ca1c8dc74606"
+  name = "github.com/kevinburke/ssh_config"
+  packages = ["."]
+  pruneopts = ""
+  revision = "81db2a75821ed34e682567d48be488a1c3121088"
+  version = "0.5"
+
+[[projects]]
+  branch = "master"
   digest = "1:212bebc561f4f654a653225868b2a97353cd5e160dc0b0bbc7232b06608474ec"
   name = "github.com/mailru/easyjson"
   packages = [
@@ -94,6 +125,14 @@
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
+  digest = "1:096a8a9182648da3d00ff243b88407838902b6703fc12657f76890e08d1899bf"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  pruneopts = ""
+  revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:84888145afd06f7e80db09851e0c4ec22996658d5075185b12040c5d46e65eee"
   name = "github.com/olivere/elastic"
   packages = [
@@ -104,6 +143,14 @@
   pruneopts = ""
   revision = "4982266e48e0dc5c639e389b50221dcef09cdc99"
   version = "v6.2.12"
+
+[[projects]]
+  digest = "1:049b5bee78dfdc9628ee0e557219c41f683e5b06c5a5f20eaba0105ccc586689"
+  name = "github.com/pelletier/go-buffruneio"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
+  version = "v0.2.0"
 
 [[projects]]
   digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
@@ -122,6 +169,14 @@
   revision = "5582a674300c427060d06980c142aeb52ed20040"
 
 [[projects]]
+  digest = "1:3962f553b77bf6c03fc07cd687a22dd3b00fe11aa14d31194f5505f5bb65cdc8"
+  name = "github.com/sergi/go-diff"
+  packages = ["diffmatchpatch"]
+  pruneopts = ""
+  revision = "1744e2970ca51c86172c8190fadad617561ed6e7"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:3fcbf733a8d810a21265a7f2fe08a3353db2407da052b233f8b204b5afc03d9b"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -130,12 +185,59 @@
   version = "v1.0.6"
 
 [[projects]]
+  digest = "1:740b31391e4c3e4d2b5a20e1cbf2c2f7765275ead23945acc7669c36c0b8095a"
+  name = "github.com/src-d/gcfg"
+  packages = [
+    ".",
+    "scanner",
+    "token",
+    "types",
+  ]
+  pruneopts = ""
+  revision = "1ac3a1ac202429a54835fe8408a92880156b489d"
+  version = "v1.4.0"
+
+[[projects]]
+  digest = "1:afc0b8068986a01e2d8f449917829753a54f6bd4d1265c2b4ad9cba75560020f"
+  name = "github.com/xanzy/ssh-agent"
+  packages = ["."]
+  pruneopts = ""
+  revision = "640f0ab560aeb89d523bb6ac322b1244d5c3796c"
+  version = "v0.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:4cae11053a5fc8e7b08228fcc14d161d3e60b64ba508a8b216937da472690991"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "cast5",
+    "curve25519",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "internal/chacha20",
+    "internal/subtle",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
+    "poly1305",
+    "ssh",
+    "ssh/agent",
+    "ssh/knownhosts",
+    "ssh/terminal",
+  ]
   pruneopts = ""
   revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
+
+[[projects]]
+  branch = "master"
+  digest = "1:4ab2fc83e3222b69759dfd717e01d0cf38b133aabfacc29a86057021a2f1abd9"
+  name = "golang.org/x/net"
+  packages = ["context"]
+  pruneopts = ""
+  revision = "927f97764cc334a6575f4b7a1584a147864d5723"
 
 [[projects]]
   branch = "master"
@@ -149,12 +251,98 @@
   revision = "4e1fef5609515ec7a2cee7b5de30ba6d9b438cbf"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
+  name = "golang.org/x/text"
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm",
+  ]
+  pruneopts = ""
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
   digest = "1:15d017551627c8bb091bde628215b2861bed128855343fdd570c62d08871f6e1"
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
   pruneopts = ""
   revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
   version = "v2.2.6"
+
+[[projects]]
+  digest = "1:cc4fc94e3088593a2cde96c032e05d1e3c7d494147d7a7d707445ccc478bf4a0"
+  name = "gopkg.in/src-d/go-billy.v4"
+  packages = [
+    ".",
+    "helper/chroot",
+    "helper/polyfill",
+    "osfs",
+    "util",
+  ]
+  pruneopts = ""
+  revision = "982626487c60a5252e7d0b695ca23fb0fa2fd670"
+  version = "v4.3.0"
+
+[[projects]]
+  digest = "1:2575e0987bd652097e3921a4713b886f786483fecac75ca0707cf7dad26424f3"
+  name = "gopkg.in/src-d/go-git.v4"
+  packages = [
+    ".",
+    "config",
+    "internal/revision",
+    "plumbing",
+    "plumbing/cache",
+    "plumbing/filemode",
+    "plumbing/format/config",
+    "plumbing/format/diff",
+    "plumbing/format/gitignore",
+    "plumbing/format/idxfile",
+    "plumbing/format/index",
+    "plumbing/format/objfile",
+    "plumbing/format/packfile",
+    "plumbing/format/pktline",
+    "plumbing/object",
+    "plumbing/protocol/packp",
+    "plumbing/protocol/packp/capability",
+    "plumbing/protocol/packp/sideband",
+    "plumbing/revlist",
+    "plumbing/storer",
+    "plumbing/transport",
+    "plumbing/transport/client",
+    "plumbing/transport/file",
+    "plumbing/transport/git",
+    "plumbing/transport/http",
+    "plumbing/transport/internal/common",
+    "plumbing/transport/server",
+    "plumbing/transport/ssh",
+    "storage",
+    "storage/filesystem",
+    "storage/filesystem/dotgit",
+    "storage/memory",
+    "utils/binary",
+    "utils/diff",
+    "utils/ioutil",
+    "utils/merkletrie",
+    "utils/merkletrie/filesystem",
+    "utils/merkletrie/index",
+    "utils/merkletrie/internal/frame",
+    "utils/merkletrie/noder",
+  ]
+  pruneopts = ""
+  revision = "3dbfb89e0f5bce0008724e547b999fe3af9f60db"
+  version = "v4.8.1"
+
+[[projects]]
+  digest = "1:ceec7e96590fb8168f36df4795fefe17051d4b0c2acc7ec4e260d8138c4dafac"
+  name = "gopkg.in/warnings.v0"
+  packages = ["."]
+  pruneopts = ""
+  revision = "ec4a0fea49c7b46c2aeb0b51aac55779c607e52b"
+  version = "v0.1.2"
 
 [[projects]]
   digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
@@ -180,6 +368,7 @@
     "github.com/remeh/sizedwaitgroup",
     "github.com/sirupsen/logrus",
     "gopkg.in/alecthomas/kingpin.v2",
+    "gopkg.in/src-d/go-git.v4",
     "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -369,6 +369,8 @@
     "github.com/sirupsen/logrus",
     "gopkg.in/alecthomas/kingpin.v2",
     "gopkg.in/src-d/go-git.v4",
+    "gopkg.in/src-d/go-git.v4/plumbing/object",
+    "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
     "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -169,6 +169,14 @@
   revision = "5582a674300c427060d06980c142aeb52ed20040"
 
 [[projects]]
+  branch = "master"
+  digest = "1:43e4ac1c95e569f24c80f9ee90c543fbeb61024c69cc731ccf33303d915488eb"
+  name = "github.com/scorredoira/email"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c1787f8317a847a7adc13673be80723268e6e639"
+
+[[projects]]
   digest = "1:3962f553b77bf6c03fc07cd687a22dd3b00fe11aa14d31194f5505f5bb65cdc8"
   name = "github.com/sergi/go-diff"
   packages = ["diffmatchpatch"]
@@ -366,6 +374,7 @@
     "github.com/olivere/elastic",
     "github.com/pkg/errors",
     "github.com/remeh/sizedwaitgroup",
+    "github.com/scorredoira/email",
     "github.com/sirupsen/logrus",
     "gopkg.in/alecthomas/kingpin.v2",
     "gopkg.in/src-d/go-git.v4",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ export ELASTICSEARCH_URI="http://localhost:9200"
 export ELASTICSEARCH_BASE_INDEX="learn"
  
 # Note: `go run` will compile eocsutil on the fly with any code changes, to compile ahead of time, use `go build` and then execute the binary
+# MongoDB URI *must* start with `mongodb:` - version 3.4 style
 go run main.go convert --from-format eocs --from-uri <path to the course files folder> --to-format eocs --to-uri mongodb://localhost:27017
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,5 +69,5 @@ Sometimes there's an issue with showdownjs nodejs service that eocsutil spawns f
 
 ### Showdownjs port conflict
 
-Interally, we use a REST API server on http://localhost:6222 to communicate with showdownjs. We're working to select a port on the fly, but until that feature is complete, you will have to either (a) modify eocsutil to use a different port or (b) temporarily stop whatever process is using port 6222 on your machine.
+Internally, we use a REST API server on http://localhost:6222 to communicate with showdownjs. We're working to select a port on the fly, but until that feature is complete, you will have to either (a) modify eocsutil to use a different port or (b) temporarily stop whatever process is using port 6222 on your machine.
 

--- a/config/config.go
+++ b/config/config.go
@@ -18,8 +18,6 @@ type Config struct {
 	GHServerMongoURI       string `envconfig:"GH_SERVER_MONGO_URI"`
 	ElasticsearchURI       string `envconfig:"ELASTICSEARCH_URI"`
 	ElasticsearchBaseIndex string `envconfig:"ELASTICSEARCH_BASE_INDEX" default:"learn"`
-	GitUser                string `envconfig:"GIT_USER" default:"Exlskills"`
-	GitUserEmail           string `envconfig:"GIT_USER_EMAIL" default:"info@exlinc.com"`
 	GitUserToken           string `envconfig:"GIT_USER_TOKEN"`
 	GitAutoGenCommitMsg    string `envconfig:"GIT_AUTOGEN_COMMIT_MSG" default:"auto#gen"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,10 @@ type Config struct {
 	GHServerMongoURI       string `envconfig:"GH_SERVER_MONGO_URI"`
 	ElasticsearchURI       string `envconfig:"ELASTICSEARCH_URI"`
 	ElasticsearchBaseIndex string `envconfig:"ELASTICSEARCH_BASE_INDEX" default:"learn"`
+	GitUser                string `envconfig:"GIT_USER" default:"Exlskills"`
+	GitUserEmail           string `envconfig:"GIT_USER_EMAIL" default:"info@exlinc.com"`
+	GitUserToken           string `envconfig:"GIT_USER_TOKEN"`
+	GitAutoGenCommitMsg    string `envconfig:"GIT_AUTOGEN_COMMIT_MSG" default:"auto#gen"`
 }
 
 var conf *Config

--- a/config/config.go
+++ b/config/config.go
@@ -16,10 +16,10 @@ type Config struct {
 	GHServerAddr           string `envconfig:"GH_SERVER_ADDR" default:"0.0.0.0"`
 	GHServerPort           string `envconfig:"GH_SERVER_PORT" default:"3344"`
 	GHServerMongoURI       string `envconfig:"GH_SERVER_MONGO_URI"`
+	GHUserToken            string `envconfig:"GH_USER_TOKEN"`
+	GHAutoGenCommitMsg     string `envconfig:"GH_AUTOGEN_COMMIT_MSG" default:"auto#gen"`
 	ElasticsearchURI       string `envconfig:"ELASTICSEARCH_URI"`
 	ElasticsearchBaseIndex string `envconfig:"ELASTICSEARCH_BASE_INDEX" default:"learn"`
-	GitUserToken           string `envconfig:"GIT_USER_TOKEN"`
-	GitAutoGenCommitMsg    string `envconfig:"GIT_AUTOGEN_COMMIT_MSG" default:"auto#gen"`
 }
 
 var conf *Config

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,12 @@ type Config struct {
 	GHAutoGenCommitMsg     string `envconfig:"GH_AUTOGEN_COMMIT_MSG" default:"auto#gen"`
 	ElasticsearchURI       string `envconfig:"ELASTICSEARCH_URI"`
 	ElasticsearchBaseIndex string `envconfig:"ELASTICSEARCH_BASE_INDEX" default:"learn"`
+	SMTPFromName           string `envconfig:"SMTP_FROM_NAME" default:"EOCS Course Loader Service"`
+	SMTPFromAddress        string `envconfig:"SMTP_FROM_ADDRESS" default:"noreply@exlskills.com"`
+	SMTPHost               string `envconfig:"SMTP_HOST" default:"smtp.sendgrid.net"`
+	SMTPConnectionString   string `envconfig:"SMTP_CONNECTION_STRING" default:"smtp.sendgrid.net:587"`
+	SMTPUserName           string `envconfig:"SMTP_USER_NAME" default:"apikey"`
+	SMTPPassword           string `envconfig:"SMTP_PASSWORD"`
 }
 
 var conf *Config

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/exlinc/golang-utils/envconfig"
 	"github.com/sirupsen/logrus"
@@ -37,7 +38,6 @@ func init() {
 	if !conf.IsDebugMode() && !conf.IsProductionMode() {
 		l.Fatal("Invalid EOCS_UTIL variable, it must be either `debug` or `production`")
 	}
-
 }
 
 // Cfg returns the configuration - will panic if the config has not been loaded or is nil (which shouldn't happen as that's implicit in the package init)
@@ -49,7 +49,17 @@ func Cfg() *Config {
 }
 
 func (cfg *Config) GetLogger() *logrus.Logger {
-	var l = logrus.New()
+	//var l = logrus.New()
+	logLvl := logrus.InfoLevel
+	if cfg.IsDebugMode() {
+		logLvl = logrus.DebugLevel
+	}
+	var l = &logrus.Logger{
+		Out:       os.Stderr,
+		Formatter: new(logrus.TextFormatter),
+		Hooks:     make(logrus.LevelHooks),
+		Level:     logLvl,
+	}
 	return l
 }
 

--- a/eocs/block.go
+++ b/eocs/block.go
@@ -86,6 +86,10 @@ func (block *Block) GetBlockType() string {
 	return block.BlockType
 }
 
+func (block *Block) GetFSPath() string {
+	return block.FSPath
+}
+
 func (block *Block) GetContentMD() (string, error) {
 	// We always have MD
 	return block.Markdown, nil

--- a/eocs/course.go
+++ b/eocs/course.go
@@ -445,7 +445,7 @@ func convertToESCourse(course *Course) (esc *esmodels.Course, exams []*esmodels.
 		SubscriptionLevel:  1,
 		ViewCount:          0,
 		EnrolledCount:      0,
-		SkillLevel:         1,
+		SkillLevel:         course.GetSkillLevel(),
 		EstMinutes:         estMinutes,
 		PrimaryTopic:       course.GetExtraAttributes()["primary_topic"],
 		CoverURL:           course.GetCourseImage(),
@@ -1055,6 +1055,7 @@ type Course struct {
 	Description       string                      `yaml:"description"`
 	Topics            []string                    `yaml:"topics,flow"`
 	PrimaryTopic      string                      `yaml:"primary_topic"`
+	SkillLevel        string                         `yaml:"skill_level"`
 	InfoMD            string                      `yaml:"info_md"`
 	RepoURL           string                      `yaml:"repo_url"`
 	Weight            int                         `yaml:"weight"`
@@ -1085,6 +1086,18 @@ func (course *Course) GetCourseImage() string {
 
 func (course *Course) GetLanguage() string {
 	return course.Language
+}
+
+func (course *Course) GetSkillLevel() int {
+	if len(course.SkillLevel) == 0 {
+		return 1
+	} else {
+		i, err := strconv.Atoi(course.SkillLevel)
+		if err != nil {
+			return 1
+		}
+		return i
+	}
 }
 
 func (course *Course) GetExtraAttributes() map[string]string {

--- a/eocs/course.go
+++ b/eocs/course.go
@@ -436,6 +436,10 @@ func convertToESCourse(course *Course) (esc *esmodels.Course, exams []*esmodels.
 		// Ensure default on error
 		weight = 0
 	}
+	skillLevel, err := course.GetSkillLevel()
+	if err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
 	esc = &esmodels.Course{
 		ID:                 course.URLName,
 		IsOrganizationOnly: false,
@@ -445,7 +449,7 @@ func convertToESCourse(course *Course) (esc *esmodels.Course, exams []*esmodels.
 		SubscriptionLevel:  1,
 		ViewCount:          0,
 		EnrolledCount:      0,
-		SkillLevel:         course.GetSkillLevel(),
+		SkillLevel:         skillLevel,
 		EstMinutes:         estMinutes,
 		PrimaryTopic:       course.GetExtraAttributes()["primary_topic"],
 		CoverURL:           course.GetCourseImage(),
@@ -888,6 +892,7 @@ func extractESSectionFeatures(courseID, courseRepoUrl, unitID string, index int,
 			GithubEditURL: ghEditUrl,
 			// TODO tags
 			Tags: []string{},
+			UpdatedAt: time.Now(),
 		}
 		section.Cards.Cards = append(section.Cards.Cards, card)
 		Log.Info("Added Card ", vert.DisplayName)
@@ -1088,15 +1093,15 @@ func (course *Course) GetLanguage() string {
 	return course.Language
 }
 
-func (course *Course) GetSkillLevel() int {
+func (course *Course) GetSkillLevel() (i int, err error) {
 	if len(course.SkillLevel) == 0 {
-		return 1
+		return 1, err
 	} else {
 		i, err := strconv.Atoi(course.SkillLevel)
 		if err != nil {
-			return 1
+			return 0, errors.New(fmt.Sprintf("invalid skill_level value in index.yaml: %s", course.SkillLevel))
 		}
-		return i
+		return i, err
 	}
 }
 

--- a/eocs/course.go
+++ b/eocs/course.go
@@ -164,7 +164,6 @@ func courseWalkFunc(rootDir string, pcx *parserCtx) filepath.WalkFunc {
 			}
 			pcx.course.Chapters[pcx.chapIdx].Sequentials = append(pcx.course.Chapters[pcx.chapIdx].Sequentials, seq)
 		} else if len(pathParts) == 3 {
-			Log.Debug("Vertical ", path)
 			// Create an index a new vertical
 			pcx.vertIdx++
 			vert := &Vertical{}
@@ -172,7 +171,7 @@ func courseWalkFunc(rootDir string, pcx *parserCtx) filepath.WalkFunc {
 			if err != nil {
 				return err
 			}
-			Log.Info("Adding vertical: ", dispName)
+			Log.Debug("Adding vertical: ", dispName)
 			if indxBytes, err := getIndexYAML(path); err == nil {
 				err = yaml.Unmarshal(indxBytes, &vert)
 				if err != nil {
@@ -271,7 +270,6 @@ func extractBlocksFromVerticalDirectory(rootPath string) (blks []*Block, err err
 				FSPath:      filepath.Join(append(rootPathParts, fi.Name())...),
 			})
 		} else if strings.HasSuffix(fi.Name(), ".md") {
-			Log.Debug("Parsing HTML %s", filepath.Join(rootPath, fi.Name()))
 			// Parse as `html` block
 			byteContents, err := ioutil.ReadFile(filepath.Join(rootPath, fi.Name()))
 			if err != nil {
@@ -515,7 +513,7 @@ func extractESFeatures(course *Course) (units []esmodels.Unit, exams []*esmodels
 }
 
 func extractESUnitFeatures(courseID string, courseRepoUrl string, chap *Chapter, nChaps int, lang string) (unit esmodels.Unit, exams []*esmodels.Exam, qs []*esmodels.Question, vc []*esmodels.VersionedContent, esearchdocs []*esmodels.ElasticsearchGenDoc, err error) {
-	Log.Info("Extracting ESUnit Features for ", chap.DisplayName)
+	Log.Debug("Extracting ESUnit Features for ", chap.DisplayName)
 	unit.ID = chap.URLName
 	unit.Title = esmodels.NewIntlStringWrapper(chap.DisplayName, lang)
 	unit.Headline = esmodels.NewIntlStringWrapper("Learn "+chap.DisplayName, lang)
@@ -777,7 +775,7 @@ func olxChoicesToESQDataArr(choices []olxproblems.Choice, lang string) ([]esmode
 // extractESSectionFeatures iterates over sequential.Verticals that represents the lowest level in the topic structure hierarchy
 // Each element in sequential.Verticals contains one set of vert.Blocks comprising one Card
 func extractESSectionFeatures(courseID, courseRepoUrl, unitID string, index int, sequential *Sequential, lang string) (section esmodels.Section, qs []*esmodels.Question, vc []*esmodels.VersionedContent, esearchdocs []*esmodels.ElasticsearchGenDoc, err error) {
-	Log.Info("Extracting ESSection Features for ", sequential.DisplayName)
+	Log.Debug("Extracting ESSection Features for ", sequential.DisplayName)
 	section.ID = sequential.URLName
 	section.Index = index + 1
 	section.Title = esmodels.NewIntlStringWrapper(sequential.DisplayName, lang)

--- a/eocs/course.go
+++ b/eocs/course.go
@@ -130,6 +130,7 @@ func courseWalkFunc(rootDir string, pcx *parserCtx) filepath.WalkFunc {
 			pcx.course.Chapters = append(pcx.course.Chapters, chap)
 		} else if len(pathParts) == 2 {
 			// Create a new sequential
+			Log.Debug("Sequential ", path)
 			pcx.vertIdx = -1
 			pcx.seqIdx++
 			seq := &Sequential{}
@@ -162,6 +163,7 @@ func courseWalkFunc(rootDir string, pcx *parserCtx) filepath.WalkFunc {
 			}
 			pcx.course.Chapters[pcx.chapIdx].Sequentials = append(pcx.course.Chapters[pcx.chapIdx].Sequentials, seq)
 		} else if len(pathParts) == 3 {
+			Log.Debug("Vertical ", path)
 			// Create an index a new vertical
 			pcx.vertIdx++
 			vert := &Vertical{}
@@ -265,6 +267,7 @@ func extractBlocksFromVerticalDirectory(rootPath string) (blks []*Block, err err
 				FSPath:      filepath.Join(append(rootPathParts, fi.Name())...),
 			})
 		} else if strings.HasSuffix(fi.Name(), ".md") {
+			Log.Debug("Parsing HTML %s",filepath.Join(rootPath, fi.Name()))
 			// Parse as `html` block
 			byteContents, err := ioutil.ReadFile(filepath.Join(rootPath, fi.Name()))
 			if err != nil {
@@ -326,6 +329,7 @@ func loadReplForEOCS(yamlBytes []byte, rootPath string) (rpl *BlockREPL, err err
 func upsertCourseRecursive(course *Course, mongoURI, dbName string, elasticsearchURI string, elasticsearchIndex string) (err error) {
 	sess, err := mgo.DialWithTimeout(mongoURI, time.Duration(10*time.Second))
 	if err != nil {
+		Log.Error("MongoDB error", err)
 		return err
 	}
 	esc, exams, qs, vcs, esearchdocs, err := convertToESCourse(course)

--- a/eocs/eocs.go
+++ b/eocs/eocs.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/exlskills/eocsutil/config"
 	"github.com/exlskills/eocsutil/eocsuri"
+	"github.com/exlskills/eocsutil/gitutils"
 	"github.com/exlskills/eocsutil/ir"
 	"os"
 )
@@ -52,5 +53,11 @@ func (e *EOCS) Push(fromUri, toUri string) error {
 	if config.Cfg().MgoDBName == "" {
 		return errors.New("for EOCS course conversion the MGO_DB_NAME environment variable must be set to the name of the MongoDB database to write to")
 	}
+	err = gitutils.SetCourseComponentsTimestamps(fromUri, course)
+	if err != nil {
+		Log.Errorf("Git reader failed with: %s", err.Error())
+		return err
+	}
+
 	return upsertCourseRecursive(course, toUri, config.Cfg().MgoDBName, config.Cfg().ElasticsearchURI, config.Cfg().ElasticsearchBaseIndex)
 }

--- a/eocs/esmodels/card.go
+++ b/eocs/esmodels/card.go
@@ -1,5 +1,7 @@
 package esmodels
 
+import "time"
+
 type Card struct {
 	ID            string            `bson:"_id"`
 	Title         IntlStringWrapper `bson:"title"`
@@ -10,4 +12,6 @@ type Card struct {
 	CourseItemRef CourseItemRef     `bson:"course_item_ref"`
 	GithubEditURL string            `bson:"github_edit_url,omitempty"`
 	Tags          []string          `bson:"tags"`
+	CreatedAt     time.Time         `bson:"created_at"`
+	UpdatedAt     time.Time         `bson:"updated_at"`
 }

--- a/eocs/vertical.go
+++ b/eocs/vertical.go
@@ -2,6 +2,7 @@ package eocs
 
 import (
 	"github.com/exlskills/eocsutil/ir"
+	"time"
 )
 
 func verticalsToIRVerticals(verts []*Vertical) []ir.Vertical {
@@ -29,9 +30,10 @@ func appendIRVerticalsToSequential(seq *Sequential, verts []ir.Vertical) (err er
 }
 
 type Vertical struct {
-	URLName     string   `yaml:"url_name"`
-	DisplayName string   `yaml:"display_name"`
-	Blocks      []*Block `yaml:"-"`
+	URLName     string    `yaml:"url_name"`
+	DisplayName string    `yaml:"display_name"`
+	Blocks      []*Block  `yaml:"-"`
+	UpdatedAt   time.Time `yaml:"-"`
 }
 
 func (vert *Vertical) GetDisplayName() string {
@@ -48,4 +50,8 @@ func (vert *Vertical) GetExtraAttributes() map[string]string {
 
 func (vert *Vertical) GetBlocks() []ir.Block {
 	return blocksToIRBlocks(vert.Blocks)
+}
+
+func (vert *Vertical) SetUpdatedAt(updatedAt time.Time)  {
+	vert.UpdatedAt = updatedAt
 }

--- a/ghmodels/repo_push_event_request.go
+++ b/ghmodels/repo_push_event_request.go
@@ -1,7 +1,8 @@
 package ghmodels
 
 type RepoPushEventRequest struct {
-	Ref string `json:"ref"`
+	Ref        string     `json:"ref"`
 	Repository Repository `json:"repository"`
+	Commits    []Commit   `json:"commits"`
 }
 

--- a/ghmodels/repo_push_event_request.go
+++ b/ghmodels/repo_push_event_request.go
@@ -4,5 +4,6 @@ type RepoPushEventRequest struct {
 	Ref        string     `json:"ref"`
 	Repository Repository `json:"repository"`
 	Commits    []Commit   `json:"commits"`
+	HeadCommit Commit     `json:"head_commit"`
 }
 

--- a/ghmodels/repository.go
+++ b/ghmodels/repository.go
@@ -1,14 +1,26 @@
 package ghmodels
 
 type Repository struct {
-	ID int64          `json:"id"`
-	Name string       `json:"name"`
-	FullName string   `json:"full_name"`
-	ArchiveURL string `json:"archive_url"`
-	CloneURL string   `json:"clone_url"`
+	ID         int64     `json:"id"`
+	Name       string    `json:"name"`
+	FullName   string    `json:"full_name"`
+	ArchiveURL string    `json:"archive_url"`
+	CloneURL   string    `json:"clone_url"`
+	RepoOwner RepoOwner  `json:"owner"`
 }
 
 type Commit struct   {
-	ID      string    `json:"id"`
-	Message string    `json:"message"`
+	ID      string       `json:"id"`
+	Message string       `json:"message"`
+	Author  CommitAuthor `json:"author"`
+}
+
+type RepoOwner struct   {
+	Name  string    `json:"name"`
+	Email string    `json:"email"`
+}
+
+type CommitAuthor struct   {
+	Name  string    `json:"name"`
+	Email string    `json:"email"`
 }

--- a/ghmodels/repository.go
+++ b/ghmodels/repository.go
@@ -1,8 +1,14 @@
 package ghmodels
 
 type Repository struct {
-	ID int64 `json:"id"`
-	Name string `json:"name"`
-	FullName string `json:"full_name"`
+	ID int64          `json:"id"`
+	Name string       `json:"name"`
+	FullName string   `json:"full_name"`
 	ArchiveURL string `json:"archive_url"`
+	CloneURL string   `json:"clone_url"`
+}
+
+type Commit struct   {
+	ID      string    `json:"id"`
+	Message string    `json:"message"`
 }

--- a/ghmodels/secure_json.go
+++ b/ghmodels/secure_json.go
@@ -30,6 +30,7 @@ func GHSecureJSONDecodeAndCatchForAPI(w http.ResponseWriter, r *http.Request, hu
 		jsonhttp.JSONForbiddenError(w, "Invalid request signature", "")
 		return errors.New("invalid signature")
 	}
+	// fmt.Println(string(reqBody))
 	err := json.Unmarshal(reqBody, &outStruct)
 	if err != nil {
 		jsonhttp.JSONBadRequestError(w, "Invalid JSON", "")

--- a/ghserver/repo_push_event_webhook.go
+++ b/ghserver/repo_push_event_webhook.go
@@ -59,7 +59,7 @@ func repoPushEventWebhookProcessor(reqObj ghmodels.RepoPushEventRequest) (messag
 	hasRealCommits := false
 	commitAuthor := ghmodels.CommitAuthor{}
 	for _, commit := range reqObj.Commits {
-		if !strings.Contains(commit.Message, config.Cfg().GitAutoGenCommitMsg) {
+		if !strings.Contains(commit.Message, config.Cfg().GHAutoGenCommitMsg) {
 			hasRealCommits = true
 			commitAuthor = commit.Author
 			break

--- a/ghserver/repo_push_event_webhook.go
+++ b/ghserver/repo_push_event_webhook.go
@@ -149,8 +149,13 @@ func repoPushEventWebhookProcessor(reqObj ghmodels.RepoPushEventRequest, mode in
 			return "An error occurred committing and pushing repo changes", err
 		}
 	}
-	if mode == asyncMode {
-		smtputils.SendEmail(reqObj.HeadCommit.Author.Email, okSubject, loadHeaderString+"<br>Process completed successfully")
+
+	msg := "Successfully imported the course"
+	if repoChanged {
+		msg = msg + ". Remote Git Repository updated! Run GIT PULL"
 	}
-	return "Successfully imported the course", nil
+	if mode == asyncMode {
+		smtputils.SendEmail(reqObj.HeadCommit.Author.Email, okSubject, loadHeaderString +"<br>" + msg)
+	}
+	return msg, nil
 }

--- a/ghserver/repo_push_event_webhook.go
+++ b/ghserver/repo_push_event_webhook.go
@@ -138,8 +138,9 @@ func repoPushEventWebhookProcessor(reqObj ghmodels.RepoPushEventRequest, mode in
 		}
 		return "An error occurred checking local repo for changes", err
 	}
+
 	if repoChanged {
-		err = gitutils.CommitAndPush(rootDir, commitAuthor)
+		err = gitutils.CommitAndPush(rootDir, commitAuthor, reqObj.HeadCommit.ID)
 		if err != nil {
 			Log.Error("An error occurred committing and pushing local repo changes: ", err)
 			if mode == asyncMode {

--- a/ghserver/repo_push_event_webhook.go
+++ b/ghserver/repo_push_event_webhook.go
@@ -5,6 +5,7 @@ import (
 	"github.com/exlskills/eocsutil/config"
 	"github.com/exlskills/eocsutil/eocs"
 	"github.com/exlskills/eocsutil/ghmodels"
+	"github.com/exlskills/eocsutil/gitutils"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -22,6 +23,26 @@ func repoPushEventWebhook(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.JSONSuccess(w, nil, "No-op, must be master branch to sync")
 		return
 	}
+
+	if len(reqObj.Commits) < 1 {
+		Log.Info("Skipping. No commits")
+		jsonhttp.JSONSuccess(w, nil, "No-op, must be commit-based")
+		return
+	}
+
+	hasRealCommits := false
+	for _, commit := range reqObj.Commits {
+		if !strings.Contains(commit.Message, config.Cfg().GitAutoGenCommitMsg) {
+			hasRealCommits = true
+			break
+		}
+	}
+	if !hasRealCommits {
+		Log.Info("Skipping. Auto-gen commits only")
+		jsonhttp.JSONSuccess(w, nil, "No-op, auto#gen commit")
+		return
+	}
+
 	rootDir, err := ioutil.TempDir("", "eocsutil-repo-dl-")
 	if err != nil {
 		Log.Error("An error occurred creating the temp directory: ", err)
@@ -29,6 +50,15 @@ func repoPushEventWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer os.RemoveAll(rootDir)
+
+	err = gitutils.CloneRepo(reqObj.Repository.CloneURL, rootDir)
+	if err != nil {
+		Log.Error("An error occurred cloning repo: ", err)
+		jsonhttp.JSONInternalError(w, "An error occurred cloning repo", "")
+		return
+	}
+
+	/*
 	archiveFileName, err := downloadFromUrl(rootDir, strings.Replace(strings.Replace(reqObj.Repository.ArchiveURL, "{/ref}", "/master", 1), "{archive_format}", "zipball", 1))
 	if err != nil {
 		Log.Error("An error occurred downloading the repo archive: ", err)
@@ -47,12 +77,30 @@ func repoPushEventWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	courseDir := unzippedFilePaths[0]
-	err = eocs.NewEOCSFormat().Push(courseDir, config.Cfg().GHServerMongoURI)
+	*/
+
+	err = eocs.NewEOCSFormat().Push(rootDir, config.Cfg().GHServerMongoURI)
 	if err != nil {
 		Log.Errorf("Course push failed: %s", err.Error())
 		jsonhttp.JSONInternalError(w, "An error occurred importing the course", "")
 		return
 	}
+
+	repoChanged, err := gitutils.IsRepoContentUpdated(rootDir)
+	if err != nil {
+		Log.Errorf("Course push failed: %s", err.Error())
+		jsonhttp.JSONInternalError(w, "An error occurred checking local repo for changes", "")
+		return
+	}
+	if repoChanged {
+		err = gitutils.CommitAndPush(rootDir,config.Cfg().GitAutoGenCommitMsg)
+		if err != nil {
+			Log.Error("An error occurred committing and pushing repo changes: ", err)
+			jsonhttp.JSONInternalError(w, "An error occurred committing and pushing repo changes", "")
+			return
+		}
+	}
+
 	jsonhttp.JSONSuccess(w, nil, "Successfully imported the course")
 	return
 }

--- a/ghserver/routes.go
+++ b/ghserver/routes.go
@@ -12,7 +12,8 @@ func createRouter() http.Handler {
 	// V1 Routes
 	v1Router := router.PathPrefix("/v1").Subrouter()
 	v1Router.HandleFunc("/", index).Methods("GET")
-	v1Router.HandleFunc("/github/repo-push-event", repoPushEventWebhook).Methods("POST")
+	v1Router.HandleFunc("/github/repo-push-event", repoPushEventWebhookLauncher).Methods("POST")
+	v1Router.HandleFunc("/github/repo-push-event-and-wait", repoPushEventWebhook).Methods("POST")
 
 	return Use(router.ServeHTTP, RecoverAndLog)
 }

--- a/gitutils/remotehandler.go
+++ b/gitutils/remotehandler.go
@@ -1,0 +1,51 @@
+package gitutils
+
+import (
+	"github.com/exlskills/eocsutil/config"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
+	"time"
+)
+
+func CloneRepo(cloneURL string, targetDir string) (err error) {
+	_, err = git.PlainClone(targetDir, false, &git.CloneOptions{
+		URL:               cloneURL,
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+	})
+	return err
+}
+
+func CommitAndPush(repoPath string, commitMsg string) (err error) {
+	r, err := git.PlainOpen(repoPath)
+	if err != nil {
+		Log.Error("Local Git Repo Open Issue", err)
+		return err
+	}
+
+	w, err := r.Worktree()
+	if err != nil {
+		Log.Error("Local Git Repo Worktree Issue", err)
+		return err
+	}
+
+	commit, err := w.Commit("auto#gen", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  config.Cfg().GitUser,
+			Email: config.Cfg().GitUserEmail,
+			When:  time.Now(),
+		},
+	})
+	if err != nil {
+		Log.Error("Local Git Repo Commit Issue", err)
+		return err
+	}
+
+	Log.Debug("Generated Commit ", commit)
+	err = r.Push(&git.PushOptions{Auth: &http.BasicAuth{
+		Username: "abc123", // anything except an empty string
+		Password: config.Cfg().GitUserToken,
+	},})
+
+	return err
+}

--- a/gitutils/remotehandler.go
+++ b/gitutils/remotehandler.go
@@ -18,7 +18,7 @@ func CloneRepo(cloneURL string, targetDir string) (err error) {
 	return err
 }
 
-func CommitAndPush(repoPath string, author ghmodels.CommitAuthor) (err error) {
+func CommitAndPush(repoPath string, author ghmodels.CommitAuthor, triggerCommit string) (err error) {
 	r, err := git.PlainOpen(repoPath)
 	if err != nil {
 		Log.Error("Local Git Repo Open Issue", err)
@@ -31,7 +31,9 @@ func CommitAndPush(repoPath string, author ghmodels.CommitAuthor) (err error) {
 		return err
 	}
 
-	commit, err := w.Commit(config.Cfg().GHAutoGenCommitMsg, &git.CommitOptions{
+	autoGenCommitMsg := config.Cfg().GHAutoGenCommitMsg + "_" + SubstringFirstN(triggerCommit,7)
+
+	commit, err := w.Commit(autoGenCommitMsg, &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  author.Name,
 			Email: author.Email,
@@ -51,4 +53,15 @@ func CommitAndPush(repoPath string, author ghmodels.CommitAuthor) (err error) {
 	},})
 
 	return err
+}
+
+func SubstringFirstN(s string, n int) string {
+	i := 0
+	for j := range s {
+		if i == n {
+			return s[:j]
+		}
+		i++
+	}
+	return s
 }

--- a/gitutils/remotehandler.go
+++ b/gitutils/remotehandler.go
@@ -31,7 +31,7 @@ func CommitAndPush(repoPath string, author ghmodels.CommitAuthor) (err error) {
 		return err
 	}
 
-	commit, err := w.Commit(config.Cfg().GitAutoGenCommitMsg, &git.CommitOptions{
+	commit, err := w.Commit(config.Cfg().GHAutoGenCommitMsg, &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  author.Name,
 			Email: author.Email,
@@ -47,7 +47,7 @@ func CommitAndPush(repoPath string, author ghmodels.CommitAuthor) (err error) {
 	Log.Debug("Commit ", commit)
 	err = r.Push(&git.PushOptions{Auth: &http.BasicAuth{
 		Username: "abc123", // anything except an empty string
-		Password: config.Cfg().GitUserToken,
+		Password: config.Cfg().GHUserToken,
 	},})
 
 	return err

--- a/gitutils/reporeader.go
+++ b/gitutils/reporeader.go
@@ -64,3 +64,42 @@ func SetCourseComponentsTimestamps(repoPath string, course ir.Course) (err error
 
 	return
 }
+
+func IsRepoContentUpdated(repoPath string) (contentChanged bool, err error) {
+	Log.Debug("In IsRepoContentUpdated")
+
+	r, err := git.PlainOpen(repoPath)
+	if err != nil {
+		Log.Error("Local Git Repo Open Issue", err)
+		return false, err
+	}
+
+	w, err := r.Worktree()
+	if err != nil {
+		Log.Error("Local Git Repo Worktree Issue", err)
+		return false, err
+	}
+
+	status, err := w.Status()
+	if err != nil {
+		Log.Error("Local Git Repo Worktree Status Issue", err)
+		return false, err
+	}
+
+	if status.IsClean() {
+		Log.Debug("No changes")
+		return false, nil
+	}
+
+	// Add All Files
+	for k, _ := range status {
+		Log.Debug("Adding File ", k)
+		_, err = w.Add(k)
+		if err != nil {
+			Log.Error("Local Git Repo Add File Issue", err)
+			return true, err
+		}
+	}
+
+	return true, nil
+}

--- a/gitutils/reporeader.go
+++ b/gitutils/reporeader.go
@@ -87,7 +87,7 @@ func IsRepoContentUpdated(repoPath string) (contentChanged bool, err error) {
 	}
 
 	if status.IsClean() {
-		Log.Debug("No changes")
+		Log.Info("No changes to Git Repo content")
 		return false, nil
 	}
 

--- a/gitutils/reporeader.go
+++ b/gitutils/reporeader.go
@@ -1,0 +1,59 @@
+package gitutils
+
+import (
+	"github.com/exlskills/eocsutil/config"
+	"github.com/exlskills/eocsutil/ir"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"time"
+)
+
+var Log = config.Cfg().GetLogger()
+
+func SetCourseComponentsTimestamps(repoPath string, course ir.Course) (err error) {
+
+	r, err := git.PlainOpen(repoPath)
+
+	if err != nil {
+		Log.Error("Local Git Repo Issue %v", err)
+		return err
+	}
+
+	for _, chapter := range course.GetChapters() {
+		for _, sequential := range chapter.GetSequentials() {
+			for _, vert := range sequential.GetVerticals() {
+				createdAt := time.Time{}
+				updatedAt := time.Time{}
+				for _, b := range vert.GetBlocks() {
+					if b.GetBlockType() == "html" {
+						fileName := b.GetFSPath()
+						Log.Debugf("Local Git File " + fileName)
+						commitsIter, err := r.Log(&git.LogOptions{FileName: &fileName, Order: git.LogOrderDFSPost,})
+						if err != nil {
+							Log.Error("Local Git Commits Issue for %s %v", fileName, err)
+							return err
+						}
+						err = commitsIter.ForEach(func(c *object.Commit) error {
+							if createdAt.IsZero() || createdAt.After(c.Author.When) {
+								createdAt = c.Author.When
+							}
+							if updatedAt.IsZero() || updatedAt.Before(c.Author.When) {
+								updatedAt = c.Author.When
+							}
+							return nil
+						})
+					}
+				}
+				if (!createdAt.IsZero()) {
+					// Future
+				}
+				if (!updatedAt.IsZero()) {
+					vert.SetUpdatedAt(updatedAt)
+				}
+
+			}
+		}
+	}
+
+	return
+}

--- a/ir/block.go
+++ b/ir/block.go
@@ -4,6 +4,7 @@ type Block interface {
 	GetDisplayName() string
 	GetURLName() string
 	GetBlockType() string
+	GetFSPath() string
 	GetContentOLX() (string, error)
 	GetContentMD() (string, error)
 	GetExtraAttributes() map[string]string

--- a/ir/vertical.go
+++ b/ir/vertical.go
@@ -1,8 +1,11 @@
 package ir
 
+import "time"
+
 type Vertical interface {
 	GetDisplayName() string
 	GetURLName() string
 	GetExtraAttributes() map[string]string
 	GetBlocks() []Block
+	SetUpdatedAt(updatedAt time.Time)
 }

--- a/main.go
+++ b/main.go
@@ -61,6 +61,8 @@ func run() {
 			}
 			return
 		}
+
+		// This is non-MongoDB only flow below
 		Log.Info("Importing course for conversion ...")
 		ir, err := getExtFmtF(*convertFromFormat).Import(verifyAndCleanURIF(*convertFromURI))
 		if err != nil {
@@ -69,7 +71,7 @@ func run() {
 		}
 		Log.Info("Successfully imported course %s for conversion, now exporting ...", ir.GetDisplayName())
 
-		err = gitutils.SetCourseComponentsTimestamps(*convertFromURI,ir)
+		err = gitutils.SetCourseComponentsTimestamps(*convertFromURI, ir)
 		if err != nil {
 			Log.Errorf("Git reader failed with: %s", err.Error())
 			return

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/exlskills/eocsutil/eocsuri"
 	"github.com/exlskills/eocsutil/extfmt"
 	"github.com/exlskills/eocsutil/ghserver"
+	"github.com/exlskills/eocsutil/gitutils"
 	"github.com/exlskills/eocsutil/mdutils"
 	"github.com/exlskills/eocsutil/olx"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -67,6 +68,14 @@ func run() {
 			return
 		}
 		Log.Info("Successfully imported course %s for conversion, now exporting ...", ir.GetDisplayName())
+
+		err = gitutils.SetCourseComponentsTimestamps(*convertFromURI,ir)
+		if err != nil {
+			Log.Errorf("Git reader failed with: %s", err.Error())
+			return
+		}
+
+
 		err = getExtFmtF(*convertToFormat).Export(ir, verifyAndCleanURIF(*convertToURI), *convertForce)
 		if err != nil {
 			Log.Errorf("Course export failed with: %s", err.Error())

--- a/olx/block.go
+++ b/olx/block.go
@@ -138,6 +138,10 @@ func (block *Block) GetURLName() string {
 	return block.URLName
 }
 
+func (block *Block) GetFSPath() string {
+	return block.Filename
+}
+
 func (block *Block) GetBlockType() string {
 	return block.ContentType
 }
@@ -162,3 +166,4 @@ func (block *Block) GetContentOLX() (string, error) {
 func (block *Block) GetExtraAttributes() map[string]string {
 	return xmlAttrsToMap(block.ExtraAttrs)
 }
+

--- a/olx/vertical.go
+++ b/olx/vertical.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 func verticalsToIRVerticals(verts []*Vertical) []ir.Vertical {
@@ -41,6 +42,7 @@ type Vertical struct {
 	DisplayName string     `xml:"display_name,attr"`
 	ExtraAttrs  []xml.Attr `xml:",any,attr"`
 	Blocks      []*Block   `xml:",any"`
+	UpdatedAt   time.Time
 }
 
 func (vert *Vertical) resolveRecursive(rootDir string) (err error) {
@@ -83,4 +85,8 @@ func (vert *Vertical) GetExtraAttributes() map[string]string {
 
 func (vert *Vertical) GetBlocks() []ir.Block {
 	return blocksToIRBlocks(vert.Blocks)
+}
+
+func (vert *Vertical) SetUpdatedAt(updatedAt time.Time)  {
+	vert.UpdatedAt = updatedAt
 }

--- a/smtputils/smtphandler.go
+++ b/smtputils/smtphandler.go
@@ -1,0 +1,24 @@
+package smtputils
+
+import (
+	"github.com/exlskills/eocsutil/config"
+	"github.com/scorredoira/email"
+	"net/mail"
+	"net/smtp"
+)
+
+var Log = config.Cfg().GetLogger()
+
+func SendEmail(toStr string, subject string, htmlBody string) error {
+	Log.Debug("In SendEmail")
+	auth := smtp.PlainAuth("", config.Cfg().SMTPUserName, config.Cfg().SMTPPassword, config.Cfg().SMTPHost)
+	m := email.NewHTMLMessage(subject, htmlBody)
+	m.From = mail.Address{Name: config.Cfg().SMTPFromName, Address: config.Cfg().SMTPFromAddress}
+	m.To = []string{toStr}
+	Log.Info("Sending Email to ",toStr)
+	err := email.Send(config.Cfg().SMTPConnectionString, auth, m)
+	if err != nil {
+		Log.Errorf("Error sending email to %s. %v",toStr,err)
+	}
+	return err
+}


### PR DESCRIPTION
SkillLevel is hard-defaulted to 1 in the course object vs. coming from the yaml as other parameters. Replaced the hardcoding with a getter function that reads the yaml as a string and defaults to int 1 if undefined (blank) - so that the logic for existing courses with no `skill_level` in the yaml remains unchanged. If a string value is provided - it is converted to int or defaulted to 1 if conversion fails 